### PR TITLE
simple inline styles

### DIFF
--- a/src/Column.js
+++ b/src/Column.js
@@ -26,6 +26,7 @@ export default class Column extends Component {
     className: PropTypes.string,
     isRoot: PropTypes.bool,
     offset: gridFraction,
+    style: PropTypes.object,
     viewport: PropTypes.array,
     width: gridFraction
   };
@@ -76,7 +77,7 @@ export default class Column extends Component {
     style.width = decimalToPercent(width[0] / width[1]);
 
     return (
-      <div className={className} style={style}>
+      <div className={className} style={{ ...style, ...this.props.style }}>
         {this.props.children}
       </div>
     );

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -29,7 +29,8 @@ export default class Grid extends Component {
     flexible: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
     gutterWidth: PropTypes.number,
     initialBreakpoint: validBreakpoint,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    style: PropTypes.object
   };
 
   static childContextTypes = gridContext;
@@ -126,10 +127,10 @@ export default class Grid extends Component {
 
   render() {
     const {breakpoint, breakCount} = this.state;
-    const {className, gutterWidth, children} = this.props;
+    const {className, gutterWidth, children, style} = this.props;
     const breakPointRange = [breakpoint, this.getMaxBreatPoint(breakpoint)];
     return (
-      <Column isRoot viewport={breakPointRange} breakCount={breakCount} className={className}>
+        <Column isRoot viewport={breakPointRange} breakCount={breakCount} className={className} style={style}>
         <Style gutter={gutterWidth}/>
         {children}
       </Column>

--- a/src/Row.js
+++ b/src/Row.js
@@ -21,7 +21,8 @@ import {forceContext} from './util/handleStaleContext';
 export default class Row extends Component {
   static propTypes = {
     children: PropTypes.any,
-    className: PropTypes.string
+    className: PropTypes.string,
+    style: PropTypes.object
   };
 
   static contextTypes = gridContext;
@@ -44,7 +45,7 @@ export default class Row extends Component {
     };
 
     return (
-      <div className={classnames(ROW, this.props.className)} style={style}>
+        <div className={classnames(ROW, this.props.className)} style={{ ...style, ...this.props.style }}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
Hi there, I really like the feel this library gives me for designing grids, but I'd like more control over each generated element. I really like using inline styles for react components - it keeps the styling tightly coupled with the view, which I think is a good thing (for my use case at least). Would you be willing to give this freedom? If not, would you consider a height-based system? I'm not sure if you'd need to duplicate all of your width-based work in this other dimension (possibly squaring the work you need to do :P) or if we could simply hard-code some kind of fixed height. Either way, I think it would be useful.