### PR TITLE
Using prop-types module rather than react PropTypes

### DIFF
--- a/example/Layout.js
+++ b/example/Layout.js
@@ -1,5 +1,6 @@
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {Grid} from '../src';
 import examples from './examples';
 import Banner from './modules/Banner';

--- a/example/modules/Blocker.js
+++ b/example/modules/Blocker.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
 /*

--- a/example/modules/Optimized.js
+++ b/example/modules/Optimized.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import TypeSize from './TypeSize';
 import {Row, Column} from '../../src';
 

--- a/package.json
+++ b/package.json
@@ -47,10 +47,11 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "cellblock": "^1.1.2",
-    "classnames": "^2.1.3",
+    "classnames": "^2.2.5",
     "eventlistener": "0.0.1",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",

--- a/src/Column.js
+++ b/src/Column.js
@@ -2,7 +2,8 @@
  * The Column component
  * divides Rows into fractions
  */
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {gridFraction} from './util/validators';
 import {COL, GRID} from './util/constants';
 import gridContext from './util/context';

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -2,7 +2,8 @@
  * The top level Grid component
  * Only used once per page
  */
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Column from './Column';
 import Style from './util/Style';
 import eventListener from 'eventlistener';

--- a/src/Row.js
+++ b/src/Row.js
@@ -3,7 +3,8 @@
  * Used inside Grid or Inside Column
  * Creates a place to nest Columns
  */
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import gridContext from './util/context';
 import classnames from 'classnames';
 import {ROW} from './util/constants';

--- a/src/util/Style.js
+++ b/src/util/Style.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import {ROW, COL} from './constants';
 
 const Style = (props) => {

--- a/src/util/context.js
+++ b/src/util/context.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 
 export default {
   cellblock: PropTypes.bool,

--- a/src/util/validators.js
+++ b/src/util/validators.js
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 
 const FRACTION_RE = /^\d+\/\d+$/;
 

--- a/test/Grid-test.js
+++ b/test/Grid-test.js
@@ -1,6 +1,7 @@
 import proxyquire from 'proxyquire';
 import {stub} from 'sinon';
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Dom, {render, findDOMNode} from 'react-dom';
 import {renderToStaticMarkup} from 'react-dom/server';
 


### PR DESCRIPTION
In the latest version of React, we get a warning in the console:

`Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs`

This fix removes that warning