### PR TITLE
Move React to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1785,6 +1785,7 @@
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
       "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.12",
         "loose-envify": "1.3.1",
@@ -8195,6 +8196,7 @@
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
       "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
+      "dev": true,
       "requires": {
         "create-react-class": "15.6.0",
         "fbjs": "0.8.12",
@@ -8223,6 +8225,7 @@
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
       "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.12",
         "loose-envify": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,7 @@
     "cellblock": "^1.1.2",
     "classnames": "^2.2.5",
     "eventlistener": "0.0.1",
-    "prop-types": "^15.5.10",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
@@ -73,8 +71,10 @@
     "node-sass": "^4.5.2",
     "nyc": "^10.2.0",
     "proxyquire": "^1.7.11",
+    "react": "^15.6.1",
     "react-addons-pure-render-mixin": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.6.1",
     "react-hot-loader": "^1.2.8",
     "require-directory": "^2.1.1",
     "sass-loader": "^6.0.3",
@@ -83,5 +83,8 @@
     "style-loader": "^0.16.1",
     "webpack": "^2.3.3",
     "webpack-dev-server": "^2.4.2"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0"
   }
 }


### PR DESCRIPTION
Fixes #20.

See https://github.com/facebook/prop-types#how-to-depend-on-this-package

I'm not actually 100% sure that this package works with React 14, so I'm happy to change `peerDependencies` accordingly, but I essentially followed React Redux: [peerDependencies](https://github.com/reactjs/react-redux/blob/master/package.json#L112) and [devDependencies](https://github.com/reactjs/react-redux/blob/master/package.json#L92-L93)