### PR TITLE
Remove browser prefixes for box-sizing

### DIFF
--- a/src/util/Style.js
+++ b/src/util/Style.js
@@ -8,7 +8,7 @@ const Style = (props) => {
   const style = `
     .${ctx} .${ROW}:after, .${ctx} .${COL}:after{content:'';display:block;height:0;visibility:hidden;clear:both;}
     .${ctx} .${ROW}{margin-left:auto;margin-right:auto;width:100%;}
-    .${ctx} .${COL}{box-sizing:border-box;-ms-box-sizing:border-box;-moz-box-sizing:border-box;width:100%;max-width:100%;float:left;min-height:1px;}
+    .${ctx} .${COL}{box-sizing:border-box;width:100%;max-width:100%;float:left;min-height:1px;}
     .${ctx} .${COL}{padding-left:${gutter}px;padding-right:${gutter}px;}
     .${ctx} .${COL} .${ROW}{margin-left:-${gutter}px;margin-right:-${gutter}px;width:auto;}
   `;


### PR DESCRIPTION
`box-sizing` is supported by all browsers, even in older versions, without a prefix.

See http://caniuse.com/#search=box-sizing